### PR TITLE
chore: 移除对 architectury api 的依赖

### DIFF
--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -28,13 +28,6 @@ ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.reflex]]
-modId = "architectury"
-type = "required"
-versionRange = "[15.0.1,)"
-ordering = "AFTER"
-side = "BOTH"
-
-[[dependencies.reflex]]
 modId = "cloth_config"
 type = "required"
 versionRange = "[0,)"


### PR DESCRIPTION
没有使用 architectury api，可以从neoforge的依赖项中移除。昨晚搞到太晚了，犯糊涂了 lol。