### PR TITLE
适配 26.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,10 @@ jobs:
         run: |
           MAJOR=$(echo "${{ steps.minecraft-version.outputs.mc_version }}" | cut -d'.' -f1)
           MINOR=$(echo "${{ steps.minecraft-version.outputs.mc_version }}" | cut -d'.' -f2)
-          if [[ $MAJOR -eq 1 ]] && [[ $MINOR -lt 21 ]]; then
+          if [[ $MAJOR -ge 26 ]]; then
+            echo "Java 25 selected for Minecraft >=26.x"
+            echo "java_version=25" >> $GITHUB_OUTPUT
+          elif [[ $MAJOR -eq 1 ]] && [[ $MINOR -lt 21 ]]; then
             echo "Java 17 selected for Minecraft <1.21.x"
             echo "java_version=17" >> $GITHUB_OUTPUT
           else
@@ -30,21 +33,19 @@ jobs:
             echo "java_version=21" >> $GITHUB_OUTPUT
           fi
       - name: Set up JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ steps.java-version.outputs.java_version }}
           distribution: 'temurin'
       - name: Cache Gradle
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: wrapper
+        uses: gradle/actions/setup-gradle@v4
       - name: Build with Gradle
         run: ./gradlew build
       - name: Upload Fabric Artifact

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,13 @@ subprojects {
     }
 
     java {
+        toolchain {
+            languageVersion = JavaLanguageVersion.of(25)
+        }
         withSourcesJar()
+    }
+
+    tasks.withType(JavaCompile).configureEach {
+        options.release = 25
     }
 }

--- a/common/src/main/java/io/tythee/GpuTimeCollector.java
+++ b/common/src/main/java/io/tythee/GpuTimeCollector.java
@@ -1,29 +1,28 @@
 package io.tythee;
 
-import org.lwjgl.opengl.GL32C;
-import org.lwjgl.opengl.GL33C;
+import com.mojang.blaze3d.systems.CommandEncoder;
+import com.mojang.blaze3d.systems.GpuDevice;
+import com.mojang.blaze3d.systems.GpuQueryPool;
+import com.mojang.blaze3d.systems.RenderSystem;
 
-import static com.mojang.blaze3d.opengl.GlConst.GL_TRUE;
+import java.util.OptionalLong;
+
 import static io.tythee.ReflexClient.LOGGER;
 
 public class GpuTimeCollector {
+    private static final int START_QUERY = 0;
+    private static final int END_QUERY = 1;
+
     public Long startTimeSystem = null;
-    public Long endTimeSystem = null;
-    public Long startTimeGpu = null;
-    public Long endTimeGpu = null;
-    public Integer startTimeQuery = null;
-    public Integer endTimeQuery = null;
+    private Long startTimeGpu = null;
+    private Long endTimeGpu = null;
+    private Long gpuTimeNs = null;
+
+    private GpuQueryPool queryPool = null;
+    private CommandEncoder queryEncoder = null;
 
     private Runnable startCallback = null;
     private Runnable endCallback = null;
-
-    long gpuToSystem(long gpu) {
-        long[] t = new long[1];
-        GL33C.glGetInteger64v(GL33C.GL_TIMESTAMP, t);
-        long system = System.nanoTime();
-        long gpuToSystemOffset = system - t[0];
-        return gpu + gpuToSystemOffset;
-    }
 
     GpuTimeCollector() {
     }
@@ -34,12 +33,23 @@ public class GpuTimeCollector {
     }
 
     public void startQueryInsert() {
-        startTimeQuery = GL32C.glGenQueries();
-        GL33C.glQueryCounter(startTimeQuery, GL33C.GL_TIMESTAMP);
-        startQueryInserted = true;
-        if (startTimeQuery == null) {
-            throw new RuntimeException("Could not find query insertion time");
+        if (queryPool != null) {
+            throw new IllegalStateException("GPU query has already been created");
         }
+
+        GpuDevice device = RenderSystem.getDevice();
+        queryPool = device.createTimestampQueryPool(2);
+        queryEncoder = device.createCommandEncoder();
+        queryEncoder.writeTimestamp(queryPool, START_QUERY);
+
+        // OpenGL executes the timestamp write immediately, so it can also be used
+        // as an approximation of the corresponding CPU time. Vulkan records the
+        // timestamp into a command buffer and does not have that property.
+        if ("OpenGL".equalsIgnoreCase(device.getDeviceInfo().backendName())) {
+            startTimeSystem = System.nanoTime();
+        }
+
+        startQueryInserted = true;
     }
 
     public void startQueryCheck() {
@@ -50,12 +60,10 @@ public class GpuTimeCollector {
         }
 
         if (startTimeGpu == null) {
-            if (GL33C.glGetQueryObjecti64(startTimeQuery, GL33C.GL_QUERY_RESULT_AVAILABLE) == GL_TRUE) {
-                startTimeGpu = GL33C.glGetQueryObjecti64(startTimeQuery, GL33C.GL_QUERY_RESULT);
-                GL32C.glDeleteQueries(startTimeQuery);
-                startTimeQuery = null;
+            OptionalLong result = queryPool.getValue(START_QUERY);
+            if (result.isPresent()) {
+                startTimeGpu = result.getAsLong();
 
-                startTimeSystem = gpuToSystem(startTimeGpu);
                 if (startCallback != null) {
                     startCallback.run();
                 }
@@ -73,8 +81,7 @@ public class GpuTimeCollector {
             throw new IllegalStateException("startQueryInsert() must be called before endQueryInsert()");
         }
 
-        endTimeQuery = GL32C.glGenQueries();
-        GL33C.glQueryCounter(endTimeQuery, GL33C.GL_TIMESTAMP);
+        queryEncoder.writeTimestamp(queryPool, END_QUERY);
 
         endQueryInserted = true;
     }
@@ -86,18 +93,19 @@ public class GpuTimeCollector {
             throw new IllegalStateException("endQueryInsert() must be called before endQueryCheck()");
         }
 
-        if (GL33C.glGetQueryObjecti64(endTimeQuery, GL33C.GL_QUERY_RESULT_AVAILABLE) == GL_TRUE) {
-            endTimeGpu = GL33C.glGetQueryObjecti64(endTimeQuery, GL33C.GL_QUERY_RESULT);
-            GL32C.glDeleteQueries(endTimeQuery);
-            endTimeQuery = null;
+        OptionalLong[] results = queryPool.getValues(0, 2);
+        if (results[0].isPresent() && results[1].isPresent()) {
+            startTimeGpu = results[0].getAsLong();
+            endTimeGpu = results[1].getAsLong();
 
-            startQueryCheck();
-            if (startTimeGpu == null) {
-                LOGGER.error("startTimeGpu is null", new IllegalStateException("startTimeGpu is null"));
-                throw new IllegalStateException("startTimeGpu is null");
-            }
+            float timestampPeriod = RenderSystem.getDevice().getDeviceInfo().timestampPeriod();
+            gpuTimeNs = Math.max(0L, (long) ((endTimeGpu - startTimeGpu) * timestampPeriod));
 
-            endTimeSystem = gpuToSystem(endTimeGpu);
+            GpuQueryPool completedQueryPool = queryPool;
+            queryPool = null;
+            queryEncoder = null;
+            completedQueryPool.close();
+
             if (endCallback != null) {
                 endCallback.run();
             }
@@ -107,13 +115,20 @@ public class GpuTimeCollector {
         return false;
     }
 
+    public Long getGpuTime() {
+        return gpuTimeNs;
+    }
+
     public void reset() {
+        if (queryPool != null) {
+            queryPool.close();
+            queryPool = null;
+        }
+        queryEncoder = null;
         startTimeSystem = null;
-        endTimeSystem = null;
         startTimeGpu = null;
         endTimeGpu = null;
-        startTimeQuery = null;
-        endTimeQuery = null;
+        gpuTimeNs = null;
         startQueryInserted = false;
         endQueryInserted = false;
     }

--- a/common/src/main/java/io/tythee/ReflexScheduler.java
+++ b/common/src/main/java/io/tythee/ReflexScheduler.java
@@ -133,7 +133,10 @@ public class ReflexScheduler {
         GpuTimeCollector gpuTimeCollector = collectorPool.borrow();
         gpuTimeCollector.setCallback(
                 null, () -> {
-                    updateGpuTime(gpuTimeCollector.endTimeSystem - gpuTimeCollector.startTimeSystem);
+                    Long gpuTime = gpuTimeCollector.getGpuTime();
+                    if (gpuTime != null) {
+                        updateGpuTime(gpuTime);
+                    }
                     collectorPool.returnObject(gpuTimeCollector);
                 });
         gpuTimeCollector.startQueryInsert();

--- a/common/src/main/java/io/tythee/mixin/MinecraftClientMixin.java
+++ b/common/src/main/java/io/tythee/mixin/MinecraftClientMixin.java
@@ -1,6 +1,5 @@
 package io.tythee.mixin;
 
-import com.mojang.authlib.minecraft.client.MinecraftClient;
 import io.tythee.CpuTimeCollector;
 import io.tythee.ReflexClient;
 import net.minecraft.client.Minecraft;
@@ -27,7 +26,7 @@ public abstract class MinecraftClientMixin {
             method = "renderFrame",
             at = @At(
                     value = "INVOKE",
-                    target = "Lcom/mojang/blaze3d/systems/RenderSystem;flipFrame(Lcom/mojang/blaze3d/TracyFrameCapture;)V"
+                    target = "Lcom/mojang/blaze3d/systems/CommandEncoder;submit()V"
             )
     )
     private void beforeFlush(CallbackInfo ci) {
@@ -38,7 +37,7 @@ public abstract class MinecraftClientMixin {
             method = "renderFrame",
             at = @At(
                     value = "INVOKE",
-                    target = "Lcom/mojang/blaze3d/systems/RenderSystem;flipFrame(Lcom/mojang/blaze3d/TracyFrameCapture;)V",
+                    target = "Lcom/mojang/blaze3d/systems/CommandEncoder;submit()V",
                     shift = At.Shift.AFTER
             )
     )

--- a/common/src/main/resources/reflex.mixins.json
+++ b/common/src/main/resources/reflex.mixins.json
@@ -1,7 +1,7 @@
 {
   "required": true,
   "package": "io.tythee.mixin",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_25",
   "minVersion": "0.8",
   "client": [
     "MinecraftClientMixin"

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -30,7 +30,7 @@
 	],
 	"depends": {
 		"fabricloader": "*",
-		"minecraft": "~26.1",
+		"minecraft": "~26.2",
 		"java": ">=25",
 		"fabric-api": "*",
 		"cloth-config": "*"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,17 +3,17 @@ org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
 # Mod properties
-mod_version = 1.0.4
+mod_version = 1.0.5
 maven_group = io.tythee
 archives_name = reflex
 enabled_platforms = fabric,neoforge
 
 # Minecraft properties
-minecraft_version = 26.1.2
+minecraft_version = 26.2
 
 # Dependencies
-fabric_loader_version = 0.19.2
-fabric_api_version = 0.148.0+26.1.2
-neoforge_version = 26.1.2.76
-modmenu_version=18.0.0-beta.1
-cloth_config_version=26.1.154
+fabric_loader_version = 0.19.3
+fabric_api_version = 0.154.2+26.2
+neoforge_version = 26.2.0.15-beta
+modmenu_version=20.0.1
+cloth_config_version=26.2.155

--- a/neoforge/src/main/resources/META-INF/neoforge.mods.toml
+++ b/neoforge/src/main/resources/META-INF/neoforge.mods.toml
@@ -16,21 +16,21 @@ logoFile = "assets/reflex/icon.png"
 [[dependencies.reflex]]
 modId = "neoforge"
 type = "required"
-versionRange = "[26.1,)"
+versionRange = "[26.2,27)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.reflex]]
 modId = "minecraft"
 type = "required"
-versionRange = "[26.1,)"
+versionRange = "[26.2,26.3)"
 ordering = "NONE"
 side = "BOTH"
 
 [[dependencies.reflex]]
 modId = "cloth_config"
 type = "required"
-versionRange = "[26.1.154,)"
+versionRange = "[26.2.155,)"
 ordering = "BEFORE"
 side = "BOTH"
 


### PR DESCRIPTION
适配Minecraft 26.2。已在服务器上测试过，效果不错

- 将原来的 `RenderSystem.flipFrame()` 注入点迁移到 `CommandEncoder.submit()`
- 使用 Minecraft 26.2 提供的 GPU Query API 替代 OpenGL 专用计时接口（因而同时兼容 OpenGL、Vulkan后端）
- Java 版本升级到 Java 25
